### PR TITLE
use mux and muy values from gdata() defaults.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -68,10 +68,6 @@ def gdata(ndata=100,mux=.5,muy=0.5):
 
     """
 
-    """Instead of getting values from URL, try from request object"""
-    mux = request.args.get('mux', '')
-    muy = request.args.get('muy', '')
-
     x = np.random.normal(mux,.5,ndata)
     y = np.random.normal(muy,.5,ndata)
     A = 10. ** np.random.rand(ndata)


### PR DESCRIPTION
@cranmer please see this pull request.

This fixes an issue where app fails if /gdata route is requested without mux and muy values. Error happens since request.args.get('mux', '') sets mux to empty string if the
value is not passed in url.

The issue can be reproduced by calling /gdata without mux and muy parameters.
